### PR TITLE
Add support for changing job_jobid_status.tsv filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ Optional Arguments:
   --max-jobs number     Maximum number of simultaneously running jobs from the job array.
   -o fmt_string, --output fmt_string
                         Slurm output file pattern. There will be one file per line in your job file. To suppress slurm out files, set this to /dev/null. Defaults to dsq-jobfile-%A_%a-%N.out
-  --status-dir dir      Directory to save the job_jobid_status.tsv file to. Defaults to working directory.
-  --suppress-stats-file  Don't save job stats to job_jobid_status.tsv
+  --status-dir dir      Directory to save the stats file to. Defaults to working directory.
+  --stats-file file     Filename of the stats file. Defaults to job_jobid_status.tsv
+  --suppress-stats-file  Don't save job stats to stats file.
   --submit              Submit the job array on the fly instead of creating a submission script.
 ```
 

--- a/dSQBatch.py
+++ b/dSQBatch.py
@@ -65,7 +65,7 @@ def parse_args():
     )
     parser.add_argument(
         "--stats-file",
-        metavar="stats-file",
+        metavar="file",
         nargs=1,
         default="job_%j_status.tsv",
         help="Filename of the stats file. Defaults to job_jobid_status.tsv."

--- a/dSQBatch.py
+++ b/dSQBatch.py
@@ -54,14 +54,21 @@ def parse_args():
     parser.add_argument(
         "--suppress-stats-file",
         action="store_true",
-        help="Don't save job stats to job_jobid_status.tsv",
+        help="Don't save job stats to stats file.",
     )
+    # parser.add_argument(
+    #    "--status-dir",
+    #    metavar="dir",
+    #    nargs=1,
+    #    default=".",
+    #    help="Directory to save the stats file to. Defaults to working directory.",
+    #)
     parser.add_argument(
-        "--status-dir",
-        metavar="dir",
+        "--stats-file",
+        metavar="stats-file",
         nargs=1,
-        default=".",
-        help="Directory to save the job_jobid_status.tsv file to. Defaults to working directory.",
+        default="./job_%j_status.tsv",
+        help="Location to save the stats.tsv file to. Defaults to ./job_jobid_status.tsv."
     )
     return parser.parse_args()
 
@@ -72,7 +79,12 @@ def run_job(args):
     # slurm calls individual job array indices "tasks"
 
     hostname = platform.node()
-
+    
+    if not args.stats_file[0].endswith(".tsv"):
+        args.stats_file[0] += ".tsv"
+    
+    args.stats_file[0] = args.stats_file[0].replace("%j", str(jid))
+    
     # use task_id to get my job out of job_file
     mycmd = ""
     with open(args.job_file[0], "r") as tf:
@@ -116,10 +128,11 @@ def run_job(args):
                 [tid, ret, hostname, time_start, time_end, time_elapsed, mycmd],
             )
         )
-
+        
         # append status file with job stats
         with open(
-            path.join(args.status_dir[0], "job_{}_status.tsv".format(jid)), "a"
+            args.stats_file[0], "a"
+            # os.path.join(args.status_dir[0], "job_{}_status.tsv".format(jid)), "a"
         ) as out_status:
             print(
                 "{Array_Task_ID}\t{Exit_Code}\t{Hostname}\t{T_Start}\t{T_End}\t{T_Elapsed:.02f}\t{Task}".format(

--- a/dSQBatch.py
+++ b/dSQBatch.py
@@ -68,7 +68,7 @@ def parse_args():
         metavar="stats-file",
         nargs=1,
         default="job_%j_status.tsv",
-        help="Location to save the stats.tsv file to. Defaults to ./job_jobid_status.tsv."
+        help="Filename of the stats file. Defaults to job_jobid_status.tsv."
     )
     return parser.parse_args()
 

--- a/dSQBatch.py
+++ b/dSQBatch.py
@@ -56,18 +56,18 @@ def parse_args():
         action="store_true",
         help="Don't save job stats to stats file.",
     )
-    # parser.add_argument(
-    #    "--status-dir",
-    #    metavar="dir",
-    #    nargs=1,
-    #    default=".",
-    #    help="Directory to save the stats file to. Defaults to working directory.",
-    #)
+    parser.add_argument(
+       "--status-dir",
+       metavar="dir",
+       nargs=1,
+       default=".",
+       help="Directory to save the stats file to. Defaults to working directory.",
+    )
     parser.add_argument(
         "--stats-file",
         metavar="stats-file",
         nargs=1,
-        default="./job_%j_status.tsv",
+        default="job_%j_status.tsv",
         help="Location to save the stats.tsv file to. Defaults to ./job_jobid_status.tsv."
     )
     return parser.parse_args()
@@ -131,7 +131,7 @@ def run_job(args):
         
         # append status file with job stats
         with open(
-            args.stats_file[0], "a"
+            os.path.join(args.status_dir[0], args.stats_file[0]), "a"
             # os.path.join(args.status_dir[0], "job_{}_status.tsv".format(jid)), "a"
         ) as out_status:
             print(


### PR DESCRIPTION
It would be helpful to be able to change the name of the `job_jobid_status.tsv` file. (In particular, I would find it useful to be able to allow it to use the job name.) Currently, it's only possible to change the directory the file is saved in using `--status-dir`, or to suppress the file entirely using `--suppress-stats-file`. I've added code to `dSQBatch.py` that should allow the user to specify the name of the stats file using a command line argument `--stats-file`. The default value is the same as the current hard-coded filename, `job_jobid_status.tsv`, so this should be backward compatible. In addition, `%j` can be used to specify the job id when specifying this argument, as it does in SBATCH options. I've also updated `README.md` to reflect this change.